### PR TITLE
bug semifix: accidental nav on pinch zoom

### DIFF
--- a/swipe2nav.js
+++ b/swipe2nav.js
@@ -3,6 +3,8 @@ var sensitivity = 50;
 var timeout = false;
 var movement = 0;
 var clearMovementTimer = null;
+var forceDisable = false;
+var pinchZoomScale = 1;
 
 // Modify movement variable and handle its reset
 const handleMovement = function(direction)
@@ -78,6 +80,9 @@ const figureoutDirection = function(event)
 // Main navigation function
 const navigate = function(event)
 {
+    // Do nothing when forceDisable is true
+    if (forceDisable) return;
+    
     // Event is scroll event from jquery.mousewheel
     goDir = figureoutDirection(event);
     // If direction is set disable scroll navigation and go
@@ -103,9 +108,22 @@ const navigate = function(event)
 }
 
 
+// Temporary solution to https://github.com/totu/Swipe2Nav/issues/11
+// Disable functionality in pinch-zoom state 
+function handleResize() 
+{
+    pinchZoomScale = window.visualViewport.scale;
+    forceDisable = (pinchZoomScale > 1);
+}   
+
 // Enable addon functionality
 const enableNav = function()
 {
+    // Detect initial pinch zoom state
+    handleResize();
+    // Hook handle resize function to detect pinch zoom
+    window.visualViewport.addEventListener('resize', handleResize);
+
     // Hook navigate function to mouse movement
     $(document).on('mousewheel', navigate);
     // Reset timeout boolean


### PR DESCRIPTION
As another pinch to zoom user I have the same issue as https://github.com/totu/Swipe2Nav/issues/11

I propose a semi solution which is disabling navigation when in pinch-zoom state.

That way this extension is still usable (better than forcefully navigated in every pinch zooms).